### PR TITLE
Named Provisioners in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "landregistry/centos-beta"
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/home/vagrant/trill", create: true
-  config.vm.provision :shell, :path => 'provision.sh'
-  config.vm.provision :shell, :path => 'extra_provision.sh'
+  config.vm.provision "standard", type: "shell", :path => 'provision.sh'
+  config.vm.provision "extras", type: "shell", :path => 'extra_provision.sh'
   config.vm.network "forwarded_port", guest: 5000, host: 5000
 
 end


### PR DESCRIPTION
Named provisioners will allow us to split provisioning into separate units and optionally select to run them individually if needed, For example, a change to the 'install.sh' file could be provisioned into a running VM with 'vagrant provision --provision-with extras'
