### PR TITLE
Initial Refactor for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ python3 /home/vagrant/trill/database-setup/load/loadDB.py
 ###Run the app:
 
 ```
-python3 run.py
+source run_dev.sh
 ```
 
 Hitting 'localhost:5000' on the browser should give you the GDS skills page.

--- a/acceptance-tests/run_tests.sh
+++ b/acceptance-tests/run_tests.sh
@@ -5,12 +5,13 @@ set -e
 rm -rf sshot*
 
 source ../environment.sh
+source ../environment_test.sh
 
 bundle install
 
 if [ -z "$1" ]
   then
-    bundle exec cucumber --tags ~@wip
+    cucumber --tags ~@wip
   else
-    bundle exec cucumber $@
+    cucumber $@
 fi

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -2,6 +2,8 @@ from flask import Flask
 from flask_bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
 
+from config import CONFIG_DICT
+
 import os
 
 app = Flask(__name__)
@@ -9,4 +11,5 @@ app = Flask(__name__)
 Bootstrap(app)
 db = SQLAlchemy(app)
 
-app.config.from_object(os.environ.get('SETTINGS'))
+#app.config.from_object(os.environ.get('SETTINGS'))
+app.config.update(CONFIG_DICT)

--- a/config.py
+++ b/config.py
@@ -1,15 +1,31 @@
 import os
 
-class Config(object):
-    DEBUG = False
+secret_key = os.environ['APPLICATION_SECRET_KEY']
+sqlalchemy_database_uri = os.environ['SQLALCHEMY_DATABASE_URI']
+
+CONFIG_DICT = {
+    'DEBUG': False,
+    'SECRET_KEY': secret_key,
+    'SQLALCHEMY_DATABASE_URI': sqlalchemy_database_uri,
+}
+
+settings = os.environ.get('SETTINGS')
+
+if settings == 'development':
+    CONFIG_DICT['DEBUG'] = True
+elif settings == 'test':
+    CONFIG_DICT['DEBUG'] = True
+
+#class Config(object):
+#    DEBUG = False
     # LOGGING_PATH = os.getenv('LOGGING_PATH', 'python_logging/logging.yaml')
 
-class DevelopmentConfig(Config):
+#class DevelopmentConfig(Config):
     # format is dialect+driver://username:password@host:port/database
-    SQLALCHEMY_DATABASE_URI = 'postgresql://trill:@0.0.0.0:5432/trill'
-    DEBUG = True
+#    SQLALCHEMY_DATABASE_URI = 'postgresql://trill:@0.0.0.0:5432/trill'
+#    DEBUG = True
 
-class UnitTestConfig(Config):
+#class UnitTestConfig(Config):
     # Uncomment the line below when the DB is up and running
     #SQLALCHEMY_DATABASE_URI = ''
-    DEBUG = True
+#    DEBUG = True

--- a/environment-test.sh
+++ b/environment-test.sh
@@ -1,1 +1,0 @@
-export SETTINGS="config.UnitTestConfig"

--- a/environment.sh
+++ b/environment.sh
@@ -1,1 +1,6 @@
-export SETTINGS="config.DevelopmentConfig"
+#!/bin/bash
+#export SETTINGS="config.DevelopmentConfig"
+
+export SETTINGS='development'
+export APPLICATION_SECRET_KEY='thisshouldbearandomvalue'
+export SQLALCHEMY_DATABASE_URI='postgresql://trill:@0.0.0.0:5432/trill'

--- a/environment_test.sh
+++ b/environment_test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 #export SETTINGS="config.UnitTestConfig"
 export SETTINGS='test'
-export APPLICATION_SECRET_KEY='thisshouldbearandomvalue'

--- a/environment_test.sh
+++ b/environment_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#export SETTINGS="config.UnitTestConfig"
+export SETTINGS='test'
+export APPLICATION_SECRET_KEY='thisshouldbearandomvalue'

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,8 @@ import os
 from application import app, db
 from application.models import *
 
-app.config.from_object(os.environ.get('SETTINGS'))
+#app.config.from_object(os.environ.get('SETTINGS'))
+from config import CONFIG_DICT
 
 migrate = Migrate(app, db)
 manager = Manager(app)

--- a/ruby_env_provision.sh
+++ b/ruby_env_provision.sh
@@ -27,5 +27,5 @@ echo "Installing Bundler"
   rbenv rehash
 
 echo "Installing Ruby Gems"
-  bundle install --path vendor
+  bundle install
   rbenv rehash

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ./environment.sh
+
+python3 run.py

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,10 +4,13 @@ import mock
 from application.server import app
 from application import db, database
 
+from config import CONFIG_DICT
+
 class TestSequenceFunctions(unittest.TestCase):
 
     def setUp(self):
-        app.config.from_object(os.environ.get('SETTINGS'))
+#        app.config.from_object(os.environ.get('SETTINGS'))
+        app.config.update(CONFIG_DICT)
         db.create_all()
         self.app = app
         self.app = app.test_client()


### PR DESCRIPTION
Environment/Config is now set in environment-specific scripts and the application configured according to the environment in which it is running. This will also help testing as configuration is held outside of the Python environment and can therefore be referenced by the Ruby/Cucumber environment.

Ruby config has changed and no longer installs required gems into the application structure - this was on advice during review of my first stab at the dev environment. This means you'll need to reconfigure Ruby once these changes are merged and active in your VM. I'll show you how to do this.

I've left all of the old stuff in there for information and will remove it later.

Have a look through and ask any questions!
