### PR TITLE
add support folder and files

### DIFF
--- a/acceptance-tests/features/support/config.rb
+++ b/acceptance-tests/features/support/config.rb
@@ -1,0 +1,19 @@
+require 'capybara/cucumber'
+require 'capybara/poltergeist'
+require 'selenium-webdriver'
+
+include Capybara::DSL
+
+Capybara.default_selector = :xpath
+Capybara.default_driver = :poltergeist
+Capybara.javascript_driver = :poltergeist
+Capybara.default_wait_time = 10
+Capybara.app_host = 'http://localhost:4567' # change url
+
+Capybara.register_driver :poltergeist do |app|
+ Capybara::Poltergeist::Driver.new(app, :inspector => true)
+end
+### Includes the unit testing framework
+require 'test/unit'
+### Allows the functions (assert_equals to work)
+include Test::Unit::Assertions

--- a/acceptance-tests/features/support/env.rb
+++ b/acceptance-tests/features/support/env.rb
@@ -1,0 +1,20 @@
+
+#
+# You shouldn't use like http://fixtures.landregistry.local as this will work locally
+# but not in CI. So we need to use variables which can be over written.
+# The commands below work as:
+#   $URL_Variable_Name = (If_Not_Empty_Then_Use_This_Value ||(OR) This_Is_The_Default_Value )
+#
+# The ENV[] are defined as system variables, check the ./run_tests_preview.sh as an example how they are overridden
+#
+
+$CASEWORK_FRONTEND_DOMAIN =    (ENV['CASEWORK_FRONTEND_DOMAIN']    ||   'http://casework-frontend.landregistry.local')
+$PROPERTY_FRONTEND_DOMAIN =    (ENV['PROPERTY_FRONTEND_DOMAIN']    ||   'http://property-frontend.landregistry.local')
+$MINT_API_DOMAIN =             (ENV['MINT_API_DOMAIN']             ||   'http://mint.landregistry.local')
+$SERVICE_FRONTEND_DOMAIN =     (ENV['SERVICE_FRONTEND_DOMAIN']     ||   'http://service-frontend.landregistry.local')
+$LR_SEARCH_API_DOMAIN =        (ENV['LR_SEARCH_API_DOMAIN']        ||   'http://search-api.landregistry.local')
+$SYSTEM_OF_RECORD_API_DOMAIN = (ENV['SYSTEM_OF_RECORD_API_DOMAIN'] ||   'http://system-of-record.landregistry.local')
+$LR_FIXTURES_URL =             (ENV['LR_FIXTURES_URL']             ||   'http://fixtures.landregistry.local')
+$INTRODUCTIONS_DOMAIN =        (ENV['INTRODUCTIONS_DOMAIN']        ||   'http://introductions.landregistry.local')
+$CASES_URL =                   (ENV['CASES_URL']                   ||   'http://cases.landregistry.local')
+$HISTORIAN_URL =               (ENV['HISTORIAN_URL']               ||   'http://historian.landregistry.local')

--- a/acceptance-tests/features/support/hooks.rb
+++ b/acceptance-tests/features/support/hooks.rb
@@ -1,0 +1,6 @@
+After do | scenario |
+  # If the scenario failed let's take a screenshot. It helps for debugging
+  if (scenario.failed?)
+      save_screenshot("sshot-#{Time.new.to_i}.png", :full => true)
+  end
+end


### PR DESCRIPTION
added the support folder containing the env.rb, config.rb and hooks.rb files.

this should let tests run headlessly and incorporate Matt G's environmental variable work to allow the tests to run in the various environment up to production. 
