### PR TITLE
Acceptance Testing fixes

### DIFF
--- a/acceptance-tests/features/step_definitions/trill.rb
+++ b/acceptance-tests/features/step_definitions/trill.rb
@@ -1,18 +1,3 @@
-require 'capybara'
-require 'capybara/dsl'
-#require 'rspec'
-
-include Capybara::DSL
-
-Capybara.app_host = 'localhost:4567'
-Capybara.default_selector = :css
-Capybara.default_driver = :selenium
-
-Capybara.register_driver :selenium do |app|
-Capybara::Selenium::Driver.new(app, :browser => :firefox)
-end
-
-
 Given(/^I am a User$/) do
   #pending # Write code here that turns the phrase above into concrete actions
   #no step to implement in this sprint (dog 28/4/15)
@@ -152,7 +137,7 @@ Then(/^I will not see the additional skill group information relevant to my role
   #get the additional GDS Skills Group text,
   #put it into a var, check against our known value
   #page.should have_no_content?('application.server.Skill_desc object')
-  
+
 #  content = page.body.text
 #  if content.include?('application.server.Skill_desc object')
 #    raise "my GDS skills group are is visible"

--- a/acceptance-tests/features/us53_Record_GDS_Skills.feature
+++ b/acceptance-tests/features/us53_Record_GDS_Skills.feature
@@ -30,5 +30,5 @@ Given I am a User
 And I am logged into Trill
 When I record my skills
 And exit the application
-and I am logged into Trill
+And I am logged into Trill
 Then my skills will displayed

--- a/acceptance-tests/run_tests.sh
+++ b/acceptance-tests/run_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+# Commented for the time being to prevent the entire shell session bombing out if
+# any of the called scripts/programs fail (MG 01/05/15)
+# set -e
 
 rm -rf sshot*
 


### PR DESCRIPTION
Fixed the following
- Prevent the entire shell session from being closed if cucumber, or any other program called from 'run_tests.sh' returns a non-zero exit status
- Fixed typo in US53 features file
- Removed config from test script now that we have config.rb
