### PR TITLE
add sprint 2 snippets

### DIFF
--- a/acceptance-tests/features/step_definitions/trill.rb
+++ b/acceptance-tests/features/step_definitions/trill.rb
@@ -30,6 +30,7 @@ When(/^I click on a collapsed GDS skill group$/) do
   # the default state of the group box is collpased so a single click should
   # ensure the object is in the correct state for the reminder of the test
   click_link("Customer Focus")
+  click_link("Customer Focus")
 
 end
 
@@ -119,8 +120,8 @@ Then(/^I can see the additional skill group information relevant to my role$/) d
   #get the additional GDS Skills Group text,
   #put it into a var, check against our known value
   myAdditionalGDSskillsGroup = find(:xpath, ".//*[@id='skill-desc1-1-1']").text
-  if myAdditionalGDSskillsGroup.include?('application.server.Skill_desc object')
-    puts 'ok'
+  if myAdditionalGDSskillsGroup.include?('Description Customer_Focus1')
+    puts
   else
     puts 'my additional GDS skills group =' + myAdditionalGDSskillsGroup
     raise "my GDS skills group are not visible"

--- a/acceptance-tests/features/us11_Login.feature
+++ b/acceptance-tests/features/us11_Login.feature
@@ -33,11 +33,11 @@ Scenario: Login Wrong Username
 Given I am a User
 And I use the wrong Username
 When I login into Trill
-Then I will see the error message ‘Login incorrect’
+Then I will see the error message Login incorrect
 
 @US11 @User @Login @Trill
 Scenario: Login Wrong Password
 Given I am a User
 And I use the wrong Password
 When I login into Trill
-Then I will see the error message ‘Login incorrect’
+Then I will see the error message Login incorrect

--- a/acceptance-tests/features/us34_Log_Out.feature
+++ b/acceptance-tests/features/us34_Log_Out.feature
@@ -10,4 +10,4 @@ Scenario: Record GDS Skills
 Given I am a User
 And I am logged into Trill
 When I select to log out record my skills
-Then i will be returned to the Trill Log In screen
+Then I will be returned to the Trill Log In screen

--- a/acceptance-tests/features/us53_Record_GDS_Skills.feature
+++ b/acceptance-tests/features/us53_Record_GDS_Skills.feature
@@ -21,14 +21,14 @@ Feature: Record GDS Skills
 Scenario: Record GDS Skills
 Given I am a User
 And I am logged into Trill
-When I record my skills
-Then my skills will be recorded
+When I record my GDS skills
+Then my GDS skills will be recorded
 
 @US53 @User @GDS @Trill
 Scenario: Record GDS Skills
 Given I am a User
 And I am logged into Trill
-When I record my skills
+When I record my GDS skills
 And exit the application
 And I am logged into Trill
-Then my skills will displayed
+Then my GDS skills will displayed


### PR DESCRIPTION
added a new file "sprint2.rb" to hold the ruby code for the sprint 2 user stories.
corrected a few typos and made the test steps less ambiguous in the sprint 2 feature files
corrected a failing test in us16.
