### PR TITLE
Changes for Jenkins deploy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,4 +4,5 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $dir
 
 echo "Installing Python Modules"
-pip3 install -r requirements.txt
+pip3 install -r requirements_base.txt
+pip3 install -r requirements_deploy.txt

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -15,9 +15,7 @@ alembic==0.7.5.post2
 cov-core==1.15.0
 coverage==3.7.1
 itsdangerous==0.24
-psycopg2==2.6
 py==1.4.26
 pytest==2.7.0
 pytest-cov==1.8.1
 mock==1.0.1
-mod-wsgi==4.4.11

--- a/requirements_deploy.txt
+++ b/requirements_deploy.txt
@@ -1,0 +1,2 @@
+psycopg2==2.6
+mod-wsgi==4.4.11


### PR DESCRIPTION
Python modules 'psycopg2' (for postgres) and 'mod_wsgi' (for apache) won't compile on the windows PC that runs Jenkins. As we don't need these modules for unit testing, I've split the 'requirements.txt' into 2 files.
'requirements_base.txt' contains python modules needed in all environments from dev to prod.
'requirements_deploy.txt' contains additional modules needed in environments that actually serve the application via a proper web server, so preview and prod.
