### PR TITLE
remove typos - add click event

### DIFF
--- a/acceptance-tests/features/step_definitions/reporting.rb
+++ b/acceptance-tests/features/step_definitions/reporting.rb
@@ -6,23 +6,24 @@ end
 
 
 When(/^I generate a report expecting results$/) do
-  #pending # Write code here that turns the phrase above into concrete actions
   # the report is generated once an entry is slected in the 'skill description'
-
   first(:xpath, "//*[@id='categ1']").click
   first(:xpath, "//*[@id='categ1']").select("Skills")
+  first(:xpath, "//*[@id='categ1']").click
   first(:xpath, "//*[@id='skill1']").click
   first(:xpath, "//*[@id='skill1']").select("67 - question and answer site for professional and enthusiast programmers. It's 100% free")
   first(:xpath, "//*[@id='skill1']").click
 
   first(:xpath, "//*[@id='categ2']").click
   first(:xpath, "//*[@id='categ2']").select("Skills")
+  first(:xpath, "//*[@id='categ2']").click
   first(:xpath, "//*[@id='skill2']").click
   first(:xpath, "//*[@id='skill2']").select("68 - question and answer site for professional and enthusiast programmers. It's 100% free")
   first(:xpath, "//*[@id='skill2']").click
 
   first(:xpath, "//*[@id='categ3']").click
   first(:xpath, "//*[@id='categ3']").select("Knowledge")
+  first(:xpath, "//*[@id='categ3']").click
   first(:xpath, "//*[@id='categ3']").click
   first(:xpath, "//*[@id='skill3']").click
   first(:xpath, "//*[@id='skill3']").select("121 - question and answer site for professional and enthusiast programmers. It's 100% free")
@@ -34,23 +35,24 @@ When(/^I generate a report expecting results$/) do
 end
 
 When(/^I generate a report expecting no results$/) do
-  #pending # Write code here that turns the phrase above into concrete actions
-
+  # the report is generated once an entry is slected in the 'skill description'
   first(:xpath, "//*[@id='categ1']").click
-  first(:xpath, "//*[@id='categ1']").select("Knowledge")
+  first(:xpath, "//*[@id='categ1']").select("Skills")
+  first(:xpath, "//*[@id='categ1']").click
   first(:xpath, "//*[@id='skill1']").click
   first(:xpath, "//*[@id='skill1']").select("96 - question and answer site for professional and enthusiast programmers. It's 100% free")
   first(:xpath, "//*[@id='skill1']").click
 
-
   first(:xpath, "//*[@id='categ2']").click
   first(:xpath, "//*[@id='categ2']").select("Skills")
+  first(:xpath, "//*[@id='categ2']").click
   first(:xpath, "//*[@id='skill2']").click
   first(:xpath, "//*[@id='skill2']").select("102 - question and answer site for professional and enthusiast programmers. It's 100% free")
   first(:xpath, "//*[@id='skill2']").click
 
   first(:xpath, "//*[@id='categ3']").click
   first(:xpath, "//*[@id='categ3']").select("Knowledge")
+  first(:xpath, "//*[@id='categ3']").click
   first(:xpath, "//*[@id='categ3']").click
   first(:xpath, "//*[@id='skill3']").click
   first(:xpath, "//*[@id='skill3']").select("130 - question and answer site for professional and enthusiast programmers. It's 100% free")
@@ -60,7 +62,6 @@ When(/^I generate a report expecting no results$/) do
   # first(:xpath, "//*[@id='categ111']").click
 
 end
-
 
 
 Then(/^I will see a results for the selected Expert Skill$/) do

--- a/acceptance-tests/features/support/functions.rb
+++ b/acceptance-tests/features/support/functions.rb
@@ -70,7 +70,7 @@ def check_value_match(myTestArea, myXpath, myValue1)
   myTextToTest = find(:xpath, myXpath).text
   if myTextToTest != myValue1
     puts 'my value = *' + myTextToTest + '* test area = *' + myTestArea
-    raise "my test vaue does not match" + myTestArea
+    raise "my test value does not match" + myTestArea
   end
 end
 
@@ -82,6 +82,6 @@ def check_value_include(myTestArea, myXpath, myValue1)
   #  puts 'passing - my value =' + myTextToTest + ' test area = ' + myTestArea
   else
     puts 'my value = *' + myTextToTest + '* test area = *' + myTestArea
-    raise "my test vaue does not match" + myTestArea
+    raise "my test value does not match" + myTestArea
   end
 end


### PR DESCRIPTION
remove typos and add a click event to ensure 'skills' selected correctly.
